### PR TITLE
add japicmp checks to integration-test module

### DIFF
--- a/dataenum-integration-test/pom.xml
+++ b/dataenum-integration-test/pom.xml
@@ -42,11 +42,38 @@
         <artifactId>fmt-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- don't deploy this artifact -->
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.11.0</version>
         <configuration>
+          <!-- enable once we've released 1.0.2 -->
           <skip>true</skip>
+          <oldVersion>
+            <dependency>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <version>1.0.2-SNAPSHOT</version>
+              <type>jar</type>
+            </dependency>
+          </oldVersion>
+          <newVersion>
+            <file>
+              <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+            </file>
+          </newVersion>
+          <parameter>
+            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+          </parameter>
         </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/dataenum-integration-test/pom.xml
+++ b/dataenum-integration-test/pom.xml
@@ -77,4 +77,22 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <!-- no need to check coverage for this artifact -->
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/dataenum-integration-test/src/main/java/com/spotify/dataenim/apicompat/MostThings_dataenum.java
+++ b/dataenum-integration-test/src/main/java/com/spotify/dataenim/apicompat/MostThings_dataenum.java
@@ -1,0 +1,41 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.dataenim.apicompat;
+
+import com.spotify.dataenim.apicompat.subpackage.Other_dataenum;
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/** Starting point for dataenum API compatibility tests. */
+@DataEnum
+public interface MostThings_dataenum<T> {
+  dataenum_case SimpleTypes(String s, Integer i, int unboxed);
+
+  dataenum_case Collections(Set<String> set, List<Boolean> list);
+
+  dataenum_case TypeParameter(T thing);
+
+  dataenum_case ReferencesOther(Other_dataenum other);
+
+  dataenum_case NullableParameter(@Nullable String maybeNull);
+}

--- a/dataenum-integration-test/src/main/java/com/spotify/dataenim/apicompat/subpackage/Other_dataenum.java
+++ b/dataenum-integration-test/src/main/java/com/spotify/dataenim/apicompat/subpackage/Other_dataenum.java
@@ -1,0 +1,28 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.dataenim.apicompat.subpackage;
+
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+public interface Other_dataenum {
+  dataenum_case Another();
+}


### PR DESCRIPTION
This is a preparatory commit. To fully enable, we first need a release that
creates a jar file with the apicompat test classes. The idea is to generate a jar file (reusing the 
integration-test module) with classes that were created with the current stable version of 
DataEnum, and use that to validate that snapshot versions generate code that is api-compatible
with the previous one.

We should continuously update the `<oldVersion>` config to point to the latest released version, since it may happen that we add methods to the generated code. If we keep pointing to an old version, the following scenario might happen:

1. Stable version is 17.
1. In version 18, method `foo(int x)` is added to generated types.
1. In version 19, the signature of `foo` is changed to `foo(int x, int y)`, breaking API compatibility of generated code.