### PR TITLE
activate japicmp checking against dataenum and dataenum-integration-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: java
 jdk:
   - oraclejdk9
 
-script: mvn -Pcoverage clean verify
+before_install:
+  - echo "MAVEN_OPTS='--add-modules java.xml.bind'" > ~/.mavenrc
+
+script:
+  - mvn -Pcoverage clean verify
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,15 @@
 Releasing
 ========
 
-1. Checkout latest master
-2. Update `README.md` so that all mentions of version name is up-to-date, commit and push update.
-3. Make sure you are on a clean master and everything is pushed to upstream.
-5. Run `mvn release:prepare release:perform` and follow the instructions.
-6. Enter the release version when prompted or press Enter for default (Please double check the version if you do so).
-7. Enter the next development version when prompted or press Enter for default (Please double check the version if you do so).
+1. Ensure you are set up for deploying to Maven Central.
+1. Run `mvn release:prepare release:perform` and follow the instructions.
+1. Enter the release version when prompted or press Enter for default (Please double check the version if you do so).
+1. Enter the next development version when prompted or press Enter for default (Please double check the version if you do so).
+1. Add release notes to the newly created tag on https://github.com/spotify/dataenum/releases.
+1. Once the new release has propagated to Maven Central, update the `last.version` property in the
+   root pom.xml to indicate the right version. Failing to do so means opening up for this:
+   1. `last.version` points to version 14.
+   1. version 15 is released, adding the method `foo(Integer i)`.
+   1. version 16 is released, changing signature of `foo` to `foo(Boolean b)`. This is an API-breaking
+      change that goes undetected, since japicmp is only checking against version 14, where `foo`
+      didn't exist.

--- a/dataenum-integration-test/pom.xml
+++ b/dataenum-integration-test/pom.xml
@@ -44,36 +44,6 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.11.0</version>
-        <configuration>
-          <!-- enable once we've released 1.0.2 -->
-          <skip>true</skip>
-          <oldVersion>
-            <dependency>
-              <groupId>${project.groupId}</groupId>
-              <artifactId>${project.artifactId}</artifactId>
-              <version>1.0.2-SNAPSHOT</version>
-              <type>jar</type>
-            </dependency>
-          </oldVersion>
-          <newVersion>
-            <file>
-              <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
-            </file>
-          </newVersion>
-          <parameter>
-            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
-            <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
-          </parameter>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>cmp</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/dataenum/pom.xml
+++ b/dataenum/pom.xml
@@ -46,6 +46,10 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <last.release>1.0.2</last.release>
     </properties>
 
     <modules>
@@ -122,6 +123,38 @@
                     <configuration>
                         <skipCheckLicense>true</skipCheckLicense>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>0.11.0</version>
+                    <configuration>
+                        <oldVersion>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${last.release}</version>
+                                <type>jar</type>
+                            </dependency>
+                        </oldVersion>
+                        <newVersion>
+                            <file>
+                                <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+                            </file>
+                        </newVersion>
+                        <parameter>
+                            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                            <onlyModified>true</onlyModified>
+                        </parameter>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>cmp</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This means that backwards-incompatible changes to either of those two modules leads to breaking builds.