### PR TITLE
Support incremental compilation with Gradle

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
@@ -66,7 +66,8 @@ public class DataEnumProcessor extends AbstractProcessor {
         TypeSpec outputTypeSpec =
             SpecTypeFactory.create(
                 outputSpec,
-                accessSelector.accessModifierFor(outputSpec.outputClass().packageName()));
+                accessSelector.accessModifierFor(outputSpec.outputClass().packageName()),
+                element);
 
         JavaFile.Builder javaFileBuilder =
             JavaFile.builder(outputSpec.outputClass().packageName(), outputTypeSpec);

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
@@ -38,13 +38,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Generated;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 
 public final class SpecTypeFactory {
 
   private SpecTypeFactory() {}
 
-  public static TypeSpec create(OutputSpec spec, Optional<Modifier> constructorAccessModifier)
+  public static TypeSpec create(
+      OutputSpec spec, Optional<Modifier> constructorAccessModifier, Element element)
       throws ParserException {
     List<TypeSpec> valueTypes = new ArrayList<>();
     List<MethodSpec> factoryMethods = new ArrayList<>();
@@ -67,6 +69,7 @@ public final class SpecTypeFactory {
 
     TypeSpec.Builder enumBuilder =
         TypeSpec.classBuilder(spec.outputClass())
+            .addOriginatingElement(element)
             .addAnnotation(
                 AnnotationSpec.builder(Generated.class)
                     .addMember(

--- a/dataenum-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/dataenum-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+com.spotify.dataenum.processor.DataEnumProcessor,isolating


### PR DESCRIPTION
Gradle 4.7 introduced support for incremental compilation for well-behaved annotation
processors. This PR marks dataenum-processor as well-behaved and means Gradle chooses
incremental compilation if all other annotation processors also support incremental compilation.