### PR TITLE
permit any annotation named  Redacted when redacting

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ if (message.isLogin()) {
   ```java
   dataenum_case UserInfo(String name, @Redacted String password);
   ```    
+  We provide an annotation in the runtime dependencies, but any annotation named `Redacted` will work.
 
 ## Configuration
 

--- a/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/OuterIntegrationTest.java
+++ b/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/OuterIntegrationTest.java
@@ -94,4 +94,9 @@ public class OuterIntegrationTest {
         .contains("i want to see this")
         .doesNotContain("866");
   }
+
+  @Test
+  public void shouldSupportAnyRedactedAnnotation() {
+    assertThat(RedactedTesting.redactMe("hide this").toString()).doesNotContain("hide this");
+  }
 }

--- a/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/Redacted.java
+++ b/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/Redacted.java
@@ -1,0 +1,33 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.dataenum.it;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Proprietary 'Redacted' annotation to ensure that you can use any - this helps avoiding conflicts
+ * with auto-value-redacted, for instance.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.PARAMETER)
+public @interface Redacted {}

--- a/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/RedactedTesting_dataenum.java
+++ b/dataenum-integration-test/src/test/java/com/spotify/dataenum/it/RedactedTesting_dataenum.java
@@ -1,0 +1,29 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.dataenum.it;
+
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+interface RedactedTesting_dataenum {
+
+  dataenum_case RedactMe(@Redacted String foo);
+}

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/parser/ValueParser.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/parser/ValueParser.java
@@ -19,7 +19,6 @@
  */
 package com.spotify.dataenum.processor.parser;
 
-import com.spotify.dataenum.Redacted;
 import com.spotify.dataenum.dataenum_case;
 import com.spotify.dataenum.function.Function;
 import com.spotify.dataenum.processor.data.Parameter;
@@ -90,8 +89,7 @@ final class ValueParser {
       TypeName parameterType = TypeName.get(parameterElement.asType());
 
       boolean nullable = isAnnotationPresent(parameterElement, ValueParser::isNullableAnnotation);
-      boolean redacted =
-          isAnnotationPresent(parameterElement, ValueParser.isRedactedAnnotation(processingEnv));
+      boolean redacted = isAnnotationPresent(parameterElement, ValueParser::isRedactedAnnotation);
       Element parameterTypeElement =
           processingEnv.getTypeUtils().asElement(parameterElement.asType());
       boolean isEnum =
@@ -102,17 +100,6 @@ final class ValueParser {
 
     String valueSimpleName = methodElement.getSimpleName().toString();
     return new Value(valueSimpleName, parameters);
-  }
-
-  private static Function<AnnotationMirror, Boolean> isRedactedAnnotation(
-      ProcessingEnvironment processingEnv) {
-    final Types types = processingEnv.getTypeUtils();
-    final Elements elements = processingEnv.getElementUtils();
-
-    return annotationMirror ->
-        types.isSameType(
-            annotationMirror.getAnnotationType(),
-            elements.getTypeElement(Redacted.class.getCanonicalName()).asType());
   }
 
   private static boolean isAnnotationPresent(
@@ -135,7 +122,11 @@ final class ValueParser {
   }
 
   private static boolean isNullableAnnotation(AnnotationMirror annotation) {
-    Element annotationElement = annotation.getAnnotationType().asElement();
-    return "Nullable".contentEquals(annotationElement.getSimpleName());
+    return "Nullable".contentEquals(annotation.getAnnotationType().asElement().getSimpleName());
+  }
+
+  private static boolean isRedactedAnnotation(AnnotationMirror annotationMirror) {
+    return "Redacted"
+        .contentEquals(annotationMirror.getAnnotationType().asElement().getSimpleName());
   }
 }


### PR DESCRIPTION
This helps avoid conflicts with annotations created to use [auto-value-redacted](https://github.com/square/auto-value-redacted), for instance.