### PR TITLE
Properly parse type parameters and substitute _dataenum references.

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputSpecFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputSpecFactory.java
@@ -32,12 +32,12 @@ public final class OutputSpecFactory {
 
   private OutputSpecFactory() {}
 
-  static final String SUFFIX = "_dataenum";
+  private static final String SUFFIX = "_dataenum";
 
   public static OutputSpec create(Spec spec) throws ParserException {
     ClassName specClass = spec.specClass();
 
-    ClassName outputClass = toOutputClass(specClass);
+    ClassName outputClass = toOutputClassName(specClass);
 
     List<OutputValue> values = new ArrayList<>();
     for (Value value : spec.values()) {
@@ -47,12 +47,15 @@ public final class OutputSpecFactory {
     return new OutputSpec(spec, outputClass, values);
   }
 
-  static ClassName toOutputClass(ClassName dataEnumClass) throws ParserException {
+  static boolean isSpecClassName(ClassName specClassName) {
+    return specClassName.simpleName().endsWith(SUFFIX);
+  }
 
-    String packageName = dataEnumClass.packageName();
-    String name = dataEnumClass.simpleName();
+  static ClassName toOutputClassName(ClassName specClassName) throws ParserException {
+    String packageName = specClassName.packageName();
+    String name = specClassName.simpleName();
 
-    if (!name.endsWith(SUFFIX)) {
+    if (!isSpecClassName(specClassName)) {
       throw new ParserException(
           String.format(
               "Bad name for DataEnum interface! Name must end with '%s', found: %s", SUFFIX, name));

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
@@ -118,6 +118,9 @@ final class OutputValueFactory {
         if (typeVariable.equals(typeArgument)) {
           return true;
         }
+        if (typeNeedsTypeVariable(typeArgument, typeVariable)) {
+          return true;
+        }
       }
     }
 

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
@@ -19,7 +19,8 @@
  */
 package com.spotify.dataenum.processor.generator.data;
 
-import static com.spotify.dataenum.processor.generator.data.OutputSpecFactory.toOutputClass;
+import static com.spotify.dataenum.processor.generator.data.OutputSpecFactory.isSpecClassName;
+import static com.spotify.dataenum.processor.generator.data.OutputSpecFactory.toOutputClassName;
 
 import com.spotify.dataenum.processor.data.OutputValue;
 import com.spotify.dataenum.processor.data.Parameter;
@@ -47,29 +48,50 @@ final class OutputValueFactory {
 
     List<Parameter> parameters = new ArrayList<>();
     for (Parameter parameter : value.parameters()) {
-      TypeName rawParamType = withoutTypeParameters(parameter.type());
-
-      if (isDataEnumParameter(rawParamType)) {
-        TypeName paramOutputType =
-            withParametersFromOther(toOutputClass((ClassName) rawParamType), parameter.type());
-        parameters.add(
-            new Parameter(
-                parameter.name(),
-                paramOutputType,
-                parameter.canBeNull(),
-                parameter.redacted(),
-                false));
-      } else {
-        parameters.add(parameter);
-      }
+      parameters.add(parameterWithoutDataEnumSuffix(parameter));
     }
 
     return new OutputValue(outputClass, value.name(), parameters, typeVariables);
   }
 
-  private static boolean isDataEnumParameter(TypeName rawParamType) {
-    return rawParamType.toString().endsWith(OutputSpecFactory.SUFFIX)
-        && rawParamType instanceof ClassName;
+  private static Parameter parameterWithoutDataEnumSuffix(Parameter parameter)
+      throws ParserException {
+    return new Parameter(
+        parameter.name(),
+        typeWithoutDataEnumSuffixes(parameter.type()),
+        parameter.canBeNull(),
+        parameter.redacted(),
+        parameter.isEnum());
+  }
+
+  private static TypeName typeWithoutDataEnumSuffixes(TypeName typeName) throws ParserException {
+    if (typeName instanceof ParameterizedTypeName) {
+      ParameterizedTypeName paramTypeName = (ParameterizedTypeName) typeName;
+
+      ClassName outputClassName;
+      if (isSpecClassName(paramTypeName.rawType)) {
+        outputClassName = toOutputClassName(paramTypeName.rawType);
+      } else {
+        outputClassName = paramTypeName.rawType;
+      }
+
+      TypeName[] typeArgumentsArr = new TypeName[paramTypeName.typeArguments.size()];
+      for (int i = 0; i < typeArgumentsArr.length; i++) {
+        typeArgumentsArr[i] = typeWithoutDataEnumSuffixes(paramTypeName.typeArguments.get(i));
+      }
+
+      return ParameterizedTypeName.get(outputClassName, typeArgumentsArr);
+    }
+
+    if (typeName instanceof ClassName) {
+      ClassName className = (ClassName) typeName;
+      if (isSpecClassName(className)) {
+        return toOutputClassName(className);
+      }
+      return className;
+    }
+
+    return typeName;
   }
 
   private static Iterable<TypeVariableName> getTypeVariables(
@@ -106,21 +128,5 @@ final class OutputValueFactory {
       }
     }
     return false;
-  }
-
-  private static TypeName withoutTypeParameters(TypeName typeName) {
-    if (typeName instanceof ParameterizedTypeName) {
-      return ((ParameterizedTypeName) typeName).rawType;
-    }
-    return typeName;
-  }
-
-  private static TypeName withParametersFromOther(ClassName className, TypeName other) {
-    if (other instanceof ParameterizedTypeName) {
-      List<TypeName> typeArguments = ((ParameterizedTypeName) other).typeArguments;
-      TypeName[] typeArgumentsArr = typeArguments.toArray(new TypeName[] {});
-      return ParameterizedTypeName.get(className, typeArgumentsArr);
-    }
-    return className;
   }
 }

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/generator/data/OutputSpecFactoryTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/generator/data/OutputSpecFactoryTest.java
@@ -32,13 +32,14 @@ public class OutputSpecFactoryTest {
   @Test
   public void shouldRemoveDataEnumInterfaceSuffix() throws Exception {
     assertThat(
-        OutputSpecFactory.toOutputClass(ClassName.get("com.spotify", "My_dataenum")),
+        OutputSpecFactory.toOutputClassName(ClassName.get("com.spotify", "My_dataenum")),
         is(ClassName.get("com.spotify", "My")));
   }
 
   @Test
   public void shouldThrowForNonDataenumClassName() throws Exception {
-    assertThatThrownBy(() -> OutputSpecFactory.toOutputClass(ClassName.get("com.spotify", "My")))
+    assertThatThrownBy(
+            () -> OutputSpecFactory.toOutputClassName(ClassName.get("com.spotify", "My")))
         .isInstanceOf(ParserException.class)
         .hasMessageContaining("Bad name");
   }

--- a/dataenum-processor/src/test/resources/GenericValues.java
+++ b/dataenum-processor/src/test/resources/GenericValues.java
@@ -28,12 +28,12 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.lang.SuppressWarnings;
 import java.lang.Throwable;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.spotify.dataenum.processor.DataEnumProcessor")
 public abstract class GenericValues<L, R extends Throwable> {
-
   GenericValues() {
   }
 
@@ -53,6 +53,10 @@ public abstract class GenericValues<L, R extends Throwable> {
     return new Both<L, R>(one, two).asGenericValues();
   }
 
+  public static <L, R extends Throwable> GenericValues<L, R> wrapped(@Nonnull Set<Set<L>> setOfSetOfL) {
+    return new Wrapped<L>(setOfSetOfL).asGenericValues();
+  }
+
   public final boolean isLeft() {
     return (this instanceof Left);
   }
@@ -67,6 +71,10 @@ public abstract class GenericValues<L, R extends Throwable> {
 
   public final boolean isBoth() {
     return (this instanceof Both);
+  }
+
+  public final boolean isWrapped() {
+    return (this instanceof Wrapped);
   }
 
   @SuppressWarnings("unchecked")
@@ -87,20 +95,20 @@ public abstract class GenericValues<L, R extends Throwable> {
     return (Both<L, R>) this;
   }
 
-  public abstract void match(
-      @Nonnull Consumer<Left<L>> left,
-      @Nonnull Consumer<Right<R>> right,
-      @Nonnull Consumer<Neither> neither,
-      @Nonnull Consumer<Both<L, R>> both);
+  @SuppressWarnings("unchecked")
+  public final Wrapped<L> asWrapped() {
+    return (Wrapped<L>) this;
+  }
 
-  public abstract <R_> R_ map(
-      @Nonnull Function<Left<L>, R_> left,
-      @Nonnull Function<Right<R>, R_> right,
-      @Nonnull Function<Neither, R_> neither,
-      @Nonnull Function<Both<L, R>, R_> both);
+  public abstract void match(@Nonnull Consumer<Left<L>> left, @Nonnull Consumer<Right<R>> right,
+                             @Nonnull Consumer<Neither> neither, @Nonnull Consumer<Both<L, R>> both,
+                             @Nonnull Consumer<Wrapped<L>> wrapped);
+
+  public abstract <R_> R_ map(@Nonnull Function<Left<L>, R_> left,
+                              @Nonnull Function<Right<R>, R_> right, @Nonnull Function<Neither, R_> neither,
+                              @Nonnull Function<Both<L, R>, R_> both, @Nonnull Function<Wrapped<L>, R_> wrapped);
 
   public static final class Left<L> extends GenericValues<L, Throwable> {
-
     private final L other;
 
     Left(L other) {
@@ -134,20 +142,16 @@ public abstract class GenericValues<L, R extends Throwable> {
     }
 
     @Override
-    public final void match(
-        @Nonnull Consumer<Left<L>> left,
-        @Nonnull Consumer<Right<Throwable>> right,
-        @Nonnull Consumer<Neither> neither,
-        @Nonnull Consumer<Both<L, Throwable>> both) {
+    public final void match(@Nonnull Consumer<Left<L>> left,
+                            @Nonnull Consumer<Right<Throwable>> right, @Nonnull Consumer<Neither> neither,
+                            @Nonnull Consumer<Both<L, Throwable>> both, @Nonnull Consumer<Wrapped<L>> wrapped) {
       left.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(
-        @Nonnull Function<Left<L>, R_> left,
-        @Nonnull Function<Right<Throwable>, R_> right,
-        @Nonnull Function<Neither, R_> neither,
-        @Nonnull Function<Both<L, Throwable>, R_> both) {
+    public final <R_> R_ map(@Nonnull Function<Left<L>, R_> left,
+                             @Nonnull Function<Right<Throwable>, R_> right, @Nonnull Function<Neither, R_> neither,
+                             @Nonnull Function<Both<L, Throwable>, R_> both, @Nonnull Function<Wrapped<L>, R_> wrapped) {
       return left.apply(this);
     }
 
@@ -158,7 +162,6 @@ public abstract class GenericValues<L, R extends Throwable> {
   }
 
   public static final class Right<R extends Throwable> extends GenericValues<Object, R> {
-
     private final R error;
 
     Right(R error) {
@@ -192,20 +195,17 @@ public abstract class GenericValues<L, R extends Throwable> {
     }
 
     @Override
-    public final void match(
-        @Nonnull Consumer<Left<Object>> left,
-        @Nonnull Consumer<Right<R>> right,
-        @Nonnull Consumer<Neither> neither,
-        @Nonnull Consumer<Both<Object, R>> both) {
+    public final void match(@Nonnull Consumer<Left<Object>> left, @Nonnull Consumer<Right<R>> right,
+                            @Nonnull Consumer<Neither> neither, @Nonnull Consumer<Both<Object, R>> both,
+                            @Nonnull Consumer<Wrapped<Object>> wrapped) {
       right.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(
-        @Nonnull Function<Left<Object>, R_> left,
-        @Nonnull Function<Right<R>, R_> right,
-        @Nonnull Function<Neither, R_> neither,
-        @Nonnull Function<Both<Object, R>, R_> both) {
+    public final <R_> R_ map(@Nonnull Function<Left<Object>, R_> left,
+                             @Nonnull Function<Right<R>, R_> right, @Nonnull Function<Neither, R_> neither,
+                             @Nonnull Function<Both<Object, R>, R_> both,
+                             @Nonnull Function<Wrapped<Object>, R_> wrapped) {
       return right.apply(this);
     }
 
@@ -216,7 +216,6 @@ public abstract class GenericValues<L, R extends Throwable> {
   }
 
   public static final class Neither extends GenericValues<Object, Throwable> {
-
     private final String s;
 
     Neither(String s) {
@@ -250,20 +249,18 @@ public abstract class GenericValues<L, R extends Throwable> {
     }
 
     @Override
-    public final void match(
-        @Nonnull Consumer<Left<Object>> left,
-        @Nonnull Consumer<Right<Throwable>> right,
-        @Nonnull Consumer<Neither> neither,
-        @Nonnull Consumer<Both<Object, Throwable>> both) {
+    public final void match(@Nonnull Consumer<Left<Object>> left,
+                            @Nonnull Consumer<Right<Throwable>> right, @Nonnull Consumer<Neither> neither,
+                            @Nonnull Consumer<Both<Object, Throwable>> both,
+                            @Nonnull Consumer<Wrapped<Object>> wrapped) {
       neither.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(
-        @Nonnull Function<Left<Object>, R_> left,
-        @Nonnull Function<Right<Throwable>, R_> right,
-        @Nonnull Function<Neither, R_> neither,
-        @Nonnull Function<Both<Object, Throwable>, R_> both) {
+    public final <R_> R_ map(@Nonnull Function<Left<Object>, R_> left,
+                             @Nonnull Function<Right<Throwable>, R_> right, @Nonnull Function<Neither, R_> neither,
+                             @Nonnull Function<Both<Object, Throwable>, R_> both,
+                             @Nonnull Function<Wrapped<Object>, R_> wrapped) {
       return neither.apply(this);
     }
 
@@ -274,7 +271,6 @@ public abstract class GenericValues<L, R extends Throwable> {
   }
 
   public static final class Both<L, R extends Throwable> extends GenericValues<L, R> {
-
     private final L one;
 
     private final R two;
@@ -320,18 +316,72 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public final void match(@Nonnull Consumer<Left<L>> left, @Nonnull Consumer<Right<R>> right,
-        @Nonnull Consumer<Neither> neither, @Nonnull Consumer<Both<L, R>> both) {
+                            @Nonnull Consumer<Neither> neither, @Nonnull Consumer<Both<L, R>> both,
+                            @Nonnull Consumer<Wrapped<L>> wrapped) {
       both.accept(this);
     }
 
     @Override
     public final <R_> R_ map(@Nonnull Function<Left<L>, R_> left,
-        @Nonnull Function<Right<R>, R_> right, @Nonnull Function<Neither, R_> neither,
-        @Nonnull Function<Both<L, R>, R_> both) {
+                             @Nonnull Function<Right<R>, R_> right, @Nonnull Function<Neither, R_> neither,
+                             @Nonnull Function<Both<L, R>, R_> both, @Nonnull Function<Wrapped<L>, R_> wrapped) {
       return both.apply(this);
     }
 
     public final GenericValues<L, R> asGenericValues() {
+      return (GenericValues<L, R>) this;
+    }
+  }
+
+  public static final class Wrapped<L> extends GenericValues<L, Throwable> {
+    private final Set<Set<L>> setOfSetOfL;
+
+    Wrapped(Set<Set<L>> setOfSetOfL) {
+      this.setOfSetOfL = checkNotNull(setOfSetOfL);
+    }
+
+    @Nonnull
+    public final Set<Set<L>> setOfSetOfL() {
+      return setOfSetOfL;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof Wrapped)) return false;
+      Wrapped<?> o = (Wrapped<?>) other;
+      return o.setOfSetOfL.equals(this.setOfSetOfL);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      return result * 31 + setOfSetOfL.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Wrapped{setOfSetOfL=").append(setOfSetOfL);
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Left<L>> left,
+                            @Nonnull Consumer<Right<Throwable>> right, @Nonnull Consumer<Neither> neither,
+                            @Nonnull Consumer<Both<L, Throwable>> both, @Nonnull Consumer<Wrapped<L>> wrapped) {
+      wrapped.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Left<L>, R_> left,
+                             @Nonnull Function<Right<Throwable>, R_> right, @Nonnull Function<Neither, R_> neither,
+                             @Nonnull Function<Both<L, Throwable>, R_> both, @Nonnull Function<Wrapped<L>, R_> wrapped) {
+      return wrapped.apply(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    public final <R extends Throwable> GenericValues<L, R> asGenericValues() {
       return (GenericValues<L, R>) this;
     }
   }

--- a/dataenum-processor/src/test/resources/GenericValues_dataenum.java
+++ b/dataenum-processor/src/test/resources/GenericValues_dataenum.java
@@ -19,6 +19,7 @@
  */
 import com.spotify.dataenum.DataEnum;
 import com.spotify.dataenum.dataenum_case;
+import java.util.Set;
 
 @DataEnum
 interface GenericValues_dataenum<L, R extends Throwable> {
@@ -26,4 +27,5 @@ interface GenericValues_dataenum<L, R extends Throwable> {
   dataenum_case Right(R error);
   dataenum_case Neither(String s);
   dataenum_case Both(L one, R two);
+  dataenum_case Wrapped(Set<Set<L>> setOfSetOfL);
 }

--- a/dataenum-processor/src/test/resources/RecursiveValue.java
+++ b/dataenum-processor/src/test/resources/RecursiveValue.java
@@ -19,13 +19,13 @@
  */
 import static com.spotify.dataenum.DataenumUtils.checkNotNull;
 
-
 import com.spotify.dataenum.function.Consumer;
 import com.spotify.dataenum.function.Function;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
@@ -38,17 +38,31 @@ public abstract class RecursiveValue {
     return new Value(child);
   }
 
+  public static RecursiveValue typeParamValue(@Nonnull Set<RecursiveValue> children) {
+    return new TypeParamValue(children);
+  }
+
   public final boolean isValue() {
     return (this instanceof Value);
+  }
+
+  public final boolean isTypeParamValue() {
+    return (this instanceof TypeParamValue);
   }
 
   public final Value asValue() {
     return (Value) this;
   }
 
-  public abstract void match(@Nonnull Consumer<Value> value);
+  public final TypeParamValue asTypeParamValue() {
+    return (TypeParamValue) this;
+  }
 
-  public abstract <R_> R_ map(@Nonnull Function<Value, R_> value);
+  public abstract void match(@Nonnull Consumer<Value> value,
+                             @Nonnull Consumer<TypeParamValue> typeParamValue);
+
+  public abstract <R_> R_ map(@Nonnull Function<Value, R_> value,
+                              @Nonnull Function<TypeParamValue, R_> typeParamValue);
 
   public static final class Value extends RecursiveValue {
     private final RecursiveValue child;
@@ -84,13 +98,61 @@ public abstract class RecursiveValue {
     }
 
     @Override
-    public final void match(@Nonnull Consumer<Value> value) {
+    public final void match(@Nonnull Consumer<Value> value,
+                            @Nonnull Consumer<TypeParamValue> typeParamValue) {
       value.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(@Nonnull Function<Value, R_> value) {
+    public final <R_> R_ map(@Nonnull Function<Value, R_> value,
+                             @Nonnull Function<TypeParamValue, R_> typeParamValue) {
       return value.apply(this);
+    }
+  }
+
+  public static final class TypeParamValue extends RecursiveValue {
+    private final Set<RecursiveValue> children;
+
+    TypeParamValue(Set<RecursiveValue> children) {
+      this.children = checkNotNull(children);
+    }
+
+    @Nonnull
+    public final Set<RecursiveValue> children() {
+      return children;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof TypeParamValue)) return false;
+      TypeParamValue o = (TypeParamValue) other;
+      return o.children.equals(this.children);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      return result * 31 + children.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("TypeParamValue{children=").append(children);
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Value> value,
+                            @Nonnull Consumer<TypeParamValue> typeParamValue) {
+      typeParamValue.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Value, R_> value,
+                             @Nonnull Function<TypeParamValue, R_> typeParamValue) {
+      return typeParamValue.apply(this);
     }
   }
 }

--- a/dataenum-processor/src/test/resources/RecursiveValue_dataenum.java
+++ b/dataenum-processor/src/test/resources/RecursiveValue_dataenum.java
@@ -19,8 +19,10 @@
  */
 import com.spotify.dataenum.DataEnum;
 import com.spotify.dataenum.dataenum_case;
+import java.util.Set;
 
 @DataEnum
 interface RecursiveValue_dataenum {
   dataenum_case Value(RecursiveValue_dataenum child);
+  dataenum_case TypeParamValue(Set<RecursiveValue_dataenum> children);
 }

--- a/dataenum-processor/src/test/resources/ReferencesOther.java
+++ b/dataenum-processor/src/test/resources/ReferencesOther.java
@@ -25,6 +25,7 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
+import java.util.Set;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import just.some.pkg.InPackage;
@@ -38,17 +39,45 @@ public abstract class ReferencesOther {
     return new Another(other);
   }
 
+  public static ReferencesOther typeParamAnother(@Nonnull Set<InPackage> others) {
+    return new TypeParamAnother(others);
+  }
+
+  public static ReferencesOther typeParamParamAnother(@Nonnull Set<Set<InPackage>> manyOthers) {
+    return new TypeParamParamAnother(manyOthers);
+  }
+
   public final boolean isAnother() {
     return (this instanceof Another);
+  }
+
+  public final boolean isTypeParamAnother() {
+    return (this instanceof TypeParamAnother);
+  }
+
+  public final boolean isTypeParamParamAnother() {
+    return (this instanceof TypeParamParamAnother);
   }
 
   public final Another asAnother() {
     return (Another) this;
   }
 
-  public abstract void match(@Nonnull Consumer<Another> another);
+  public final TypeParamAnother asTypeParamAnother() {
+    return (TypeParamAnother) this;
+  }
 
-  public abstract <R_> R_ map(@Nonnull Function<Another, R_> another);
+  public final TypeParamParamAnother asTypeParamParamAnother() {
+    return (TypeParamParamAnother) this;
+  }
+
+  public abstract void match(@Nonnull Consumer<Another> another,
+                             @Nonnull Consumer<TypeParamAnother> typeParamAnother,
+                             @Nonnull Consumer<TypeParamParamAnother> typeParamParamAnother);
+
+  public abstract <R_> R_ map(@Nonnull Function<Another, R_> another,
+                              @Nonnull Function<TypeParamAnother, R_> typeParamAnother,
+                              @Nonnull Function<TypeParamParamAnother, R_> typeParamParamAnother);
 
   public static final class Another extends ReferencesOther {
     private final InPackage other;
@@ -84,13 +113,113 @@ public abstract class ReferencesOther {
     }
 
     @Override
-    public final void match(@Nonnull Consumer<Another> another) {
+    public final void match(@Nonnull Consumer<Another> another,
+                            @Nonnull Consumer<TypeParamAnother> typeParamAnother,
+                            @Nonnull Consumer<TypeParamParamAnother> typeParamParamAnother) {
       another.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(@Nonnull Function<Another, R_> another) {
+    public final <R_> R_ map(@Nonnull Function<Another, R_> another,
+                             @Nonnull Function<TypeParamAnother, R_> typeParamAnother,
+                             @Nonnull Function<TypeParamParamAnother, R_> typeParamParamAnother) {
       return another.apply(this);
+    }
+  }
+
+  public static final class TypeParamAnother extends ReferencesOther {
+    private final Set<InPackage> others;
+
+    TypeParamAnother(Set<InPackage> others) {
+      this.others = checkNotNull(others);
+    }
+
+    @Nonnull
+    public final Set<InPackage> others() {
+      return others;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof TypeParamAnother)) return false;
+      TypeParamAnother o = (TypeParamAnother) other;
+      return o.others.equals(this.others);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      return result * 31 + others.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("TypeParamAnother{others=").append(others);
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Another> another,
+                            @Nonnull Consumer<TypeParamAnother> typeParamAnother,
+                            @Nonnull Consumer<TypeParamParamAnother> typeParamParamAnother) {
+      typeParamAnother.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Another, R_> another,
+                             @Nonnull Function<TypeParamAnother, R_> typeParamAnother,
+                             @Nonnull Function<TypeParamParamAnother, R_> typeParamParamAnother) {
+      return typeParamAnother.apply(this);
+    }
+  }
+
+  public static final class TypeParamParamAnother extends ReferencesOther {
+    private final Set<Set<InPackage>> manyOthers;
+
+    TypeParamParamAnother(Set<Set<InPackage>> manyOthers) {
+      this.manyOthers = checkNotNull(manyOthers);
+    }
+
+    @Nonnull
+    public final Set<Set<InPackage>> manyOthers() {
+      return manyOthers;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof TypeParamParamAnother)) return false;
+      TypeParamParamAnother o = (TypeParamParamAnother) other;
+      return o.manyOthers.equals(this.manyOthers);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      return result * 31 + manyOthers.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("TypeParamParamAnother{manyOthers=").append(manyOthers);
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Another> another,
+                            @Nonnull Consumer<TypeParamAnother> typeParamAnother,
+                            @Nonnull Consumer<TypeParamParamAnother> typeParamParamAnother) {
+      typeParamParamAnother.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Another, R_> another,
+                             @Nonnull Function<TypeParamAnother, R_> typeParamAnother,
+                             @Nonnull Function<TypeParamParamAnother, R_> typeParamParamAnother) {
+      return typeParamParamAnother.apply(this);
     }
   }
 }

--- a/dataenum-processor/src/test/resources/ReferencesOther_dataenum.java
+++ b/dataenum-processor/src/test/resources/ReferencesOther_dataenum.java
@@ -19,9 +19,12 @@
  */
 import com.spotify.dataenum.DataEnum;
 import com.spotify.dataenum.dataenum_case;
+import java.util.Set;
 import just.some.pkg.InPackage_dataenum;
 
 @DataEnum
 interface ReferencesOther_dataenum {
   dataenum_case Another(InPackage_dataenum other);
+  dataenum_case TypeParamAnother(Set<InPackage_dataenum> others);
+  dataenum_case TypeParamParamAnother(Set<Set<InPackage_dataenum>> manyOthers);
 }


### PR DESCRIPTION
DataEnum didn't properly recognize generic type parameter or _datenum references in case signatures. For example the following cases didn't generate the correct code:

```java
@DataEnum
interface Foo_dataenum<T> {
  dataenum_case Bar(Set<T> s);
  dataenum_case Baz(Set<Foo_dataenum> s);
}
```

This patch adds support for these cases but also allows further nesting eg. `Set<Set<T>>`

Resolves issue #20 