### PR TITLE
Use javax.annotation.processing.Generated for Java9+ [DO NOT MERGE]

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
@@ -42,6 +42,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 
 public class DataEnumProcessor extends AbstractProcessor {
@@ -67,7 +68,8 @@ public class DataEnumProcessor extends AbstractProcessor {
             SpecTypeFactory.create(
                 outputSpec,
                 accessSelector.accessModifierFor(outputSpec.outputClass().packageName()),
-                element);
+                element,
+                processingEnv.getElementUtils());
 
         JavaFile.Builder javaFileBuilder =
             JavaFile.builder(outputSpec.outputClass().packageName(), outputTypeSpec);


### PR DESCRIPTION
I was notified of an issue when using Bazel. It seems like the `Generated` annotation moved from `javax.annotation.Generated` to `javax.annotation.processing.Generated`. This is an attempt at fixing that. I managed to get it to work. However, the integration tests fail when I run them using JDK10 (if I remove the jsr250 dependency) because the order of imports change as well as the imported `Generated` annotation. Not sure how to proceed there. Or if this is even something that we want to do? I imagine we can just check for the existence of the annotation and require people to add jsr250-api as a dependency. Having that as a dependency and tests using JDK10 does pass.