### PR TITLE
Rename local variable in generated `hashCode`

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueTypeFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueTypeFactory.java
@@ -254,7 +254,7 @@ public class ValueTypeFactory {
       return result.build();
     }
 
-    result.addStatement("int result = 0");
+    result.addStatement("int _hash_result = 0");
 
     int parameterCount = Iterables.sizeOf(value.parameters());
     int parameterIndex = 0;
@@ -264,9 +264,9 @@ public class ValueTypeFactory {
       parameterIndex++;
 
       if (parameterIndex == parameterCount) {
-        result.addCode("return result * 31 + ");
+        result.addCode("return _hash_result * 31 + ");
       } else {
-        result.addCode("result = result * 31 + ");
+        result.addCode("_hash_result = _hash_result * 31 + ");
       }
       if (parameter.type().isPrimitive()) {
         TypeName boxedType = parameter.type().box();

--- a/dataenum-processor/src/test/resources/EfficientEquals.java
+++ b/dataenum-processor/src/test/resources/EfficientEquals.java
@@ -99,11 +99,11 @@ public abstract class EfficientEquals {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      result = result * 31 + param2.hashCode();
-      result = result * 31 + param3.hashCode();
-      return result * 31 + Double.valueOf(param4).hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + Integer.valueOf(param1).hashCode();
+      _hash_result = _hash_result * 31 + param2.hashCode();
+      _hash_result = _hash_result * 31 + param3.hashCode();
+      return _hash_result * 31 + Double.valueOf(param4).hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/GenericValues.java
+++ b/dataenum-processor/src/test/resources/GenericValues.java
@@ -130,8 +130,8 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + other.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + other.hashCode();
     }
 
     @Override
@@ -183,8 +183,8 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + error.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + error.hashCode();
     }
 
     @Override
@@ -237,8 +237,8 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + s.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + s.hashCode();
     }
 
     @Override
@@ -301,9 +301,9 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + one.hashCode();
-      return result * 31 + two.hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + one.hashCode();
+      return _hash_result * 31 + two.hashCode();
     }
 
     @Override
@@ -355,8 +355,8 @@ public abstract class GenericValues<L, R extends Throwable> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + setOfSetOfL.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + setOfSetOfL.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/InnerGenericValue.java
+++ b/dataenum-processor/src/test/resources/InnerGenericValue.java
@@ -100,8 +100,8 @@ public abstract class InnerGenericValue<T> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + values.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + values.hashCode();
     }
 
     @Override
@@ -150,8 +150,8 @@ public abstract class InnerGenericValue<T> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + value.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + value.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/MultipleValues.java
+++ b/dataenum-processor/src/test/resources/MultipleValues.java
@@ -91,9 +91,9 @@ public abstract class MultipleValues {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + Integer.valueOf(param1).hashCode();
+      return _hash_result * 31 + Boolean.valueOf(param2).hashCode();
     }
 
     @Override
@@ -145,9 +145,9 @@ public abstract class MultipleValues {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + Integer.valueOf(param1).hashCode();
+      return _hash_result * 31 + Boolean.valueOf(param2).hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/NullableValue.java
+++ b/dataenum-processor/src/test/resources/NullableValue.java
@@ -110,12 +110,12 @@ public abstract class NullableValue {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + param1.hashCode();
-      result = result * 31 + (param2 != null ? param2.hashCode() : 0);
-      result = result * 31 + (param3 != null ? param3.hashCode() : 0);
-      result = result * 31 + param4.hashCode();
-      return result * 31 + param5.hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + param1.hashCode();
+      _hash_result = _hash_result * 31 + (param2 != null ? param2.hashCode() : 0);
+      _hash_result = _hash_result * 31 + (param3 != null ? param3.hashCode() : 0);
+      _hash_result = _hash_result * 31 + param4.hashCode();
+      return _hash_result * 31 + param5.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/PrimitiveValue.java
+++ b/dataenum-processor/src/test/resources/PrimitiveValue.java
@@ -96,11 +96,11 @@ public abstract class PrimitiveValue {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      result = result * 31 + Boolean.valueOf(param2).hashCode();
-      result = result * 31 + Float.valueOf(param3).hashCode();
-      return result * 31 + Double.valueOf(param4).hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + Integer.valueOf(param1).hashCode();
+      _hash_result = _hash_result * 31 + Boolean.valueOf(param2).hashCode();
+      _hash_result = _hash_result * 31 + Float.valueOf(param3).hashCode();
+      return _hash_result * 31 + Double.valueOf(param4).hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/RecursiveGenericValue.java
+++ b/dataenum-processor/src/test/resources/RecursiveGenericValue.java
@@ -111,9 +111,9 @@ public abstract class RecursiveGenericValue<L, R> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + left.hashCode();
-      return result * 31 + right.hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + left.hashCode();
+      return _hash_result * 31 + right.hashCode();
     }
 
     @Override
@@ -163,8 +163,8 @@ public abstract class RecursiveGenericValue<L, R> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + value.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + value.hashCode();
     }
 
     @Override
@@ -214,8 +214,8 @@ public abstract class RecursiveGenericValue<L, R> {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + value.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + value.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/RecursiveValue.java
+++ b/dataenum-processor/src/test/resources/RecursiveValue.java
@@ -86,8 +86,8 @@ public abstract class RecursiveValue {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + child.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + child.hashCode();
     }
 
     @Override
@@ -132,8 +132,8 @@ public abstract class RecursiveValue {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + children.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + children.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/ReferencesOther.java
+++ b/dataenum-processor/src/test/resources/ReferencesOther.java
@@ -101,8 +101,8 @@ public abstract class ReferencesOther {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + other.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + other.hashCode();
     }
 
     @Override
@@ -149,8 +149,8 @@ public abstract class ReferencesOther {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + others.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + others.hashCode();
     }
 
     @Override
@@ -197,8 +197,8 @@ public abstract class ReferencesOther {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      return result * 31 + manyOthers.hashCode();
+      int _hash_result = 0;
+      return _hash_result * 31 + manyOthers.hashCode();
     }
 
     @Override

--- a/dataenum-processor/src/test/resources/just/some/pkg/InPackage.java
+++ b/dataenum-processor/src/test/resources/just/some/pkg/InPackage.java
@@ -80,9 +80,9 @@ public abstract class InPackage {
 
     @Override
     public int hashCode() {
-      int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      int _hash_result = 0;
+      _hash_result = _hash_result * 31 + Integer.valueOf(param1).hashCode();
+      return _hash_result * 31 + Boolean.valueOf(param2).hashCode();
     }
 
     @Override


### PR DESCRIPTION
If one of the case classes contains a parameter also called `result`, it
would break the generated code. We can avoid this scenario by prefixing
it with an unlikely name.