### PR TITLE
Allow `result` and `builder` as field names

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueTypeFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueTypeFactory.java
@@ -270,12 +270,12 @@ public class ValueTypeFactory {
       }
       if (parameter.type().isPrimitive()) {
         TypeName boxedType = parameter.type().box();
-        result.addStatement("$T.valueOf($L).hashCode()", boxedType, fieldName);
+        result.addStatement("$T.valueOf(this.$L).hashCode()", boxedType, fieldName);
       } else {
         if (parameter.canBeNull()) {
-          result.addStatement("($1L != null ? $1L.hashCode() : 0)", fieldName);
+          result.addStatement("(this.$1L != null ? this.$1L.hashCode() : 0)", fieldName);
         } else {
-          result.addStatement("$L.hashCode()", fieldName);
+          result.addStatement("this.$L.hashCode()", fieldName);
         }
       }
     }
@@ -300,7 +300,7 @@ public class ValueTypeFactory {
     for (Parameter parameter : value.parameters()) {
       String fieldName = parameter.name();
 
-      String valueFormat = parameter.redacted() ? "\"***\"" : "$1L";
+      String valueFormat = parameter.redacted() ? "\"***\"" : "this.$1L";
 
       if (first) {
         first = false;

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -53,6 +53,11 @@ public class IntegrationTest {
   }
 
   @Test
+  public void conflictingFieldNames() throws Exception {
+    assertThatEnumGeneratedMatchingFile("ConflictingFieldNames");
+  }
+
+  @Test
   public void emptyEnum() throws Exception {
     assertThatEnumGeneratedMatchingFile("Empty");
   }

--- a/dataenum-processor/src/test/resources/ConflictingFieldNames.java
+++ b/dataenum-processor/src/test/resources/ConflictingFieldNames.java
@@ -32,12 +32,12 @@ import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 
 @Generated("com.spotify.dataenum.processor.DataEnumProcessor")
-public abstract class EfficientEquals {
-  EfficientEquals() {
+public abstract class ConflictingFieldNames {
+  ConflictingFieldNames() {
   }
 
-  public static EfficientEquals value(int param1, @Nonnull String param2, @Nonnull MyEnum param3, double param4) {
-    return new Value(param1, param2, param3, param4);
+  public static ConflictingFieldNames value(int result, @Nonnull String builder, @Nonnull MyEnum param3, double param4) {
+    return new Value(result, builder, param3, param4);
   }
 
   public final boolean isValue() {
@@ -52,29 +52,29 @@ public abstract class EfficientEquals {
 
   public abstract <R_> R_ map(@Nonnull Function<Value, R_> value);
 
-  public static final class Value extends EfficientEquals {
-    private final int param1;
+  public static final class Value extends ConflictingFieldNames {
+    private final int result;
 
-    private final String param2;
+    private final String builder;
 
     private final MyEnum param3;
 
     private final double param4;
 
-    Value(int param1, String param2, MyEnum param3, double param4) {
-      this.param1 = param1;
-      this.param2 = checkNotNull(param2);
+    Value(int result, String builder, MyEnum param3, double param4) {
+      this.result = result;
+      this.builder = checkNotNull(builder);
       this.param3 = checkNotNull(param3);
       this.param4 = param4;
     }
 
-    public final int param1() {
-      return param1;
+    public final int result() {
+      return result;
     }
 
     @Nonnull
-    public final String param2() {
-      return param2;
+    public final String builder() {
+      return builder;
     }
 
     @Nonnull
@@ -91,17 +91,17 @@ public abstract class EfficientEquals {
       if (other == this) return true;
       if (!(other instanceof Value)) return false;
       Value o = (Value) other;
-      return o.param1 == param1
+      return o.result == result
           && o.param3 == param3
           && o.param4 == param4
-          && o.param2.equals(this.param2);
+          && o.builder.equals(this.builder);
     }
 
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + Integer.valueOf(this.param1).hashCode();
-      result = result * 31 + this.param2.hashCode();
+      result = result * 31 + Integer.valueOf(this.result).hashCode();
+      result = result * 31 + this.builder.hashCode();
       result = result * 31 + this.param3.hashCode();
       return result * 31 + Double.valueOf(this.param4).hashCode();
     }
@@ -109,8 +109,8 @@ public abstract class EfficientEquals {
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value{param1=").append(this.param1);
-      builder.append(", param2=").append(this.param2);
+      builder.append("Value{result=").append(this.result);
+      builder.append(", builder=").append(this.builder);
       builder.append(", param3=").append(this.param3);
       builder.append(", param4=").append(this.param4);
       return builder.append('}').toString();

--- a/dataenum-processor/src/test/resources/ConflictingFieldNames_dataenum.java
+++ b/dataenum-processor/src/test/resources/ConflictingFieldNames_dataenum.java
@@ -1,0 +1,29 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+interface ConflictingFieldNames_dataenum {
+  dataenum_case Value(int result,
+                       String builder,
+                       MyEnum param3,
+                       double param4);
+}

--- a/dataenum-processor/src/test/resources/GenericValues.java
+++ b/dataenum-processor/src/test/resources/GenericValues.java
@@ -131,13 +131,13 @@ public abstract class GenericValues<L, R extends Throwable> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + other.hashCode();
+      return result * 31 + this.other.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Left{other=").append(other);
+      builder.append("Left{other=").append(this.other);
       return builder.append('}').toString();
     }
 
@@ -184,13 +184,13 @@ public abstract class GenericValues<L, R extends Throwable> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + error.hashCode();
+      return result * 31 + this.error.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Right{error=").append(error);
+      builder.append("Right{error=").append(this.error);
       return builder.append('}').toString();
     }
 
@@ -238,13 +238,13 @@ public abstract class GenericValues<L, R extends Throwable> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + s.hashCode();
+      return result * 31 + this.s.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Neither{s=").append(s);
+      builder.append("Neither{s=").append(this.s);
       return builder.append('}').toString();
     }
 
@@ -302,15 +302,15 @@ public abstract class GenericValues<L, R extends Throwable> {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + one.hashCode();
-      return result * 31 + two.hashCode();
+      result = result * 31 + this.one.hashCode();
+      return result * 31 + this.two.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Both{one=").append(one);
-      builder.append(", two=").append(two);
+      builder.append("Both{one=").append(this.one);
+      builder.append(", two=").append(this.two);
       return builder.append('}').toString();
     }
 
@@ -356,13 +356,13 @@ public abstract class GenericValues<L, R extends Throwable> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + setOfSetOfL.hashCode();
+      return result * 31 + this.setOfSetOfL.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Wrapped{setOfSetOfL=").append(setOfSetOfL);
+      builder.append("Wrapped{setOfSetOfL=").append(this.setOfSetOfL);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/InnerGenericValue.java
+++ b/dataenum-processor/src/test/resources/InnerGenericValue.java
@@ -101,13 +101,13 @@ public abstract class InnerGenericValue<T> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + values.hashCode();
+      return result * 31 + this.values.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Many{values=").append(values);
+      builder.append("Many{values=").append(this.values);
       return builder.append('}').toString();
     }
 
@@ -151,13 +151,13 @@ public abstract class InnerGenericValue<T> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + value.hashCode();
+      return result * 31 + this.value.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("One{value=").append(value);
+      builder.append("One{value=").append(this.value);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/MultipleValues.java
+++ b/dataenum-processor/src/test/resources/MultipleValues.java
@@ -92,15 +92,15 @@ public abstract class MultipleValues {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      result = result * 31 + Integer.valueOf(this.param1).hashCode();
+      return result * 31 + Boolean.valueOf(this.param2).hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value1{param1=").append(param1);
-      builder.append(", param2=").append(param2);
+      builder.append("Value1{param1=").append(this.param1);
+      builder.append(", param2=").append(this.param2);
       return builder.append('}').toString();
     }
 
@@ -146,15 +146,15 @@ public abstract class MultipleValues {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      result = result * 31 + Integer.valueOf(this.param1).hashCode();
+      return result * 31 + Boolean.valueOf(this.param2).hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value2{param1=").append(param1);
-      builder.append(", param2=").append(param2);
+      builder.append("Value2{param1=").append(this.param1);
+      builder.append(", param2=").append(this.param2);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/NullableValue.java
+++ b/dataenum-processor/src/test/resources/NullableValue.java
@@ -111,21 +111,21 @@ public abstract class NullableValue {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + param1.hashCode();
-      result = result * 31 + (param2 != null ? param2.hashCode() : 0);
-      result = result * 31 + (param3 != null ? param3.hashCode() : 0);
-      result = result * 31 + param4.hashCode();
-      return result * 31 + param5.hashCode();
+      result = result * 31 + this.param1.hashCode();
+      result = result * 31 + (this.param2 != null ? this.param2.hashCode() : 0);
+      result = result * 31 + (this.param3 != null ? this.param3.hashCode() : 0);
+      result = result * 31 + this.param4.hashCode();
+      return result * 31 + this.param5.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value{param1=").append(param1);
-      builder.append(", param2=").append(param2);
-      builder.append(", param3=").append(param3);
-      builder.append(", param4=").append(param4);
-      builder.append(", param5=").append(param5);
+      builder.append("Value{param1=").append(this.param1);
+      builder.append(", param2=").append(this.param2);
+      builder.append(", param3=").append(this.param3);
+      builder.append(", param4=").append(this.param4);
+      builder.append(", param5=").append(this.param5);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/PrimitiveValue.java
+++ b/dataenum-processor/src/test/resources/PrimitiveValue.java
@@ -97,19 +97,19 @@ public abstract class PrimitiveValue {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      result = result * 31 + Boolean.valueOf(param2).hashCode();
-      result = result * 31 + Float.valueOf(param3).hashCode();
-      return result * 31 + Double.valueOf(param4).hashCode();
+      result = result * 31 + Integer.valueOf(this.param1).hashCode();
+      result = result * 31 + Boolean.valueOf(this.param2).hashCode();
+      result = result * 31 + Float.valueOf(this.param3).hashCode();
+      return result * 31 + Double.valueOf(this.param4).hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value{param1=").append(param1);
-      builder.append(", param2=").append(param2);
-      builder.append(", param3=").append(param3);
-      builder.append(", param4=").append(param4);
+      builder.append("Value{param1=").append(this.param1);
+      builder.append(", param2=").append(this.param2);
+      builder.append(", param3=").append(this.param3);
+      builder.append(", param4=").append(this.param4);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/RecursiveGenericValue.java
+++ b/dataenum-processor/src/test/resources/RecursiveGenericValue.java
@@ -112,15 +112,15 @@ public abstract class RecursiveGenericValue<L, R> {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + left.hashCode();
-      return result * 31 + right.hashCode();
+      result = result * 31 + this.left.hashCode();
+      return result * 31 + this.right.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Branch{left=").append(left);
-      builder.append(", right=").append(right);
+      builder.append("Branch{left=").append(this.left);
+      builder.append(", right=").append(this.right);
       return builder.append('}').toString();
     }
 
@@ -164,13 +164,13 @@ public abstract class RecursiveGenericValue<L, R> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + value.hashCode();
+      return result * 31 + this.value.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Left{value=").append(value);
+      builder.append("Left{value=").append(this.value);
       return builder.append('}').toString();
     }
 
@@ -215,13 +215,13 @@ public abstract class RecursiveGenericValue<L, R> {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + value.hashCode();
+      return result * 31 + this.value.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Right{value=").append(value);
+      builder.append("Right{value=").append(this.value);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/RecursiveValue.java
+++ b/dataenum-processor/src/test/resources/RecursiveValue.java
@@ -87,13 +87,13 @@ public abstract class RecursiveValue {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + child.hashCode();
+      return result * 31 + this.child.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value{child=").append(child);
+      builder.append("Value{child=").append(this.child);
       return builder.append('}').toString();
     }
 
@@ -133,13 +133,13 @@ public abstract class RecursiveValue {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + children.hashCode();
+      return result * 31 + this.children.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("TypeParamValue{children=").append(children);
+      builder.append("TypeParamValue{children=").append(this.children);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/ReferencesOther.java
+++ b/dataenum-processor/src/test/resources/ReferencesOther.java
@@ -102,13 +102,13 @@ public abstract class ReferencesOther {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + other.hashCode();
+      return result * 31 + this.other.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Another{other=").append(other);
+      builder.append("Another{other=").append(this.other);
       return builder.append('}').toString();
     }
 
@@ -150,13 +150,13 @@ public abstract class ReferencesOther {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + others.hashCode();
+      return result * 31 + this.others.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("TypeParamAnother{others=").append(others);
+      builder.append("TypeParamAnother{others=").append(this.others);
       return builder.append('}').toString();
     }
 
@@ -198,13 +198,13 @@ public abstract class ReferencesOther {
     @Override
     public int hashCode() {
       int result = 0;
-      return result * 31 + manyOthers.hashCode();
+      return result * 31 + this.manyOthers.hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("TypeParamParamAnother{manyOthers=").append(manyOthers);
+      builder.append("TypeParamParamAnother{manyOthers=").append(this.manyOthers);
       return builder.append('}').toString();
     }
 

--- a/dataenum-processor/src/test/resources/just/some/pkg/InPackage.java
+++ b/dataenum-processor/src/test/resources/just/some/pkg/InPackage.java
@@ -81,15 +81,15 @@ public abstract class InPackage {
     @Override
     public int hashCode() {
       int result = 0;
-      result = result * 31 + Integer.valueOf(param1).hashCode();
-      return result * 31 + Boolean.valueOf(param2).hashCode();
+      result = result * 31 + Integer.valueOf(this.param1).hashCode();
+      return result * 31 + Boolean.valueOf(this.param2).hashCode();
     }
 
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      builder.append("Value1{param1=").append(param1);
-      builder.append(", param2=").append(param2);
+      builder.append("Value1{param1=").append(this.param1);
+      builder.append(", param2=").append(this.param2);
       return builder.append('}').toString();
     }
 


### PR DESCRIPTION
The generated `hashCode` and `toString` use local variables called
`result` and `builder` respectively, causing issues if fields have the
same name. Prefixing field access with `this` solves the issue.