### PR TITLE
Use java.util.Arrays for array fields

### DIFF
--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/DataEnumProcessor.java
@@ -30,6 +30,7 @@ import com.spotify.dataenum.processor.generator.data.OutputSpecFactory;
 import com.spotify.dataenum.processor.generator.spec.SpecTypeFactory;
 import com.spotify.dataenum.processor.parser.ParserException;
 import com.spotify.dataenum.processor.parser.SpecParser;
+import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import java.io.IOException;
@@ -113,7 +114,9 @@ public class DataEnumProcessor extends AbstractProcessor {
   private static boolean needsNullSafeEquals(Spec enumDef) {
     for (Value value : enumDef.values()) {
       for (Parameter parameter : value.parameters()) {
-        if (!parameter.type().isPrimitive() && parameter.canBeNull()) {
+        if (!parameter.type().isPrimitive()
+            && !(parameter.type() instanceof ArrayTypeName)
+            && parameter.canBeNull()) {
           return true;
         }
       }

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -144,6 +144,11 @@ public class IntegrationTest {
   }
 
   @Test
+  public void arrayFields() throws Exception {
+    assertThatEnumGeneratedMatchingFile("ArrayFields");
+  }
+
+  @Test
   public void referenceOtherDataenum() throws Exception {
     Compilation compilation =
         javac()

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -149,6 +149,11 @@ public class IntegrationTest {
   }
 
   @Test
+  public void redactedStrings() throws Exception {
+    assertThatEnumGeneratedMatchingFile("Redacted");
+  }
+
+  @Test
   public void referenceOtherDataenum() throws Exception {
     Compilation compilation =
         javac()

--- a/dataenum-processor/src/test/resources/ArrayFields.java
+++ b/dataenum-processor/src/test/resources/ArrayFields.java
@@ -1,0 +1,120 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+import static com.spotify.dataenum.DataenumUtils.checkNotNull;
+
+import com.spotify.dataenum.function.Consumer;
+import com.spotify.dataenum.function.Function;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.Arrays;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Generated("com.spotify.dataenum.processor.DataEnumProcessor")
+public abstract class ArrayFields {
+  ArrayFields() {
+  }
+
+  public static ArrayFields value(@Nullable byte[] builder, @Nonnull char[] result, @Nonnull Object[] param3) {
+    return new Value(builder, result, param3);
+  }
+
+  public final boolean isValue() {
+    return (this instanceof Value);
+  }
+
+  public final Value asValue() {
+    return (Value) this;
+  }
+
+  public abstract void match(@Nonnull Consumer<Value> value);
+
+  public abstract <R_> R_ map(@Nonnull Function<Value, R_> value);
+
+  public static final class Value extends ArrayFields {
+    private final byte[] builder;
+
+    private final char[] result;
+
+    private final Object[] param3;
+
+    Value(byte[] builder, char[] result, Object[] param3) {
+      this.builder = builder;
+      this.result = checkNotNull(result);
+      this.param3 = checkNotNull(param3);
+    }
+
+    @Nullable
+    public final byte[] builder() {
+      return builder;
+    }
+
+    @Nonnull
+    public final char[] result() {
+      return result;
+    }
+
+    @Nonnull
+    public final Object[] param3() {
+      return param3;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof Value)) return false;
+      Value o = (Value) other;
+      return Arrays.equals(o.builder, builder)
+          && Arrays.equals(o.result, result)
+          && Arrays.equals(o.param3, param3);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      result = result * 31 + Arrays.hashCode(this.builder);
+      result = result * 31 + Arrays.hashCode(this.result);
+      return result * 31 + Arrays.hashCode(this.param3);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Value{builder=").append(Arrays.toString(this.builder));
+      builder.append(", result=").append(Arrays.toString(this.result));
+      builder.append(", param3=").append(Arrays.toString(this.param3));
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Value> value) {
+      value.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Value, R_> value) {
+      return value.apply(this);
+    }
+  }
+}

--- a/dataenum-processor/src/test/resources/ArrayFields_dataenum.java
+++ b/dataenum-processor/src/test/resources/ArrayFields_dataenum.java
@@ -1,0 +1,29 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+import javax.annotation.Nullable;
+
+@DataEnum
+interface ArrayFields_dataenum {
+  dataenum_case Value(@Nullable byte[] builder,
+                       char[] result,
+                       Object[] param3);
+}

--- a/dataenum-processor/src/test/resources/Redacted.java
+++ b/dataenum-processor/src/test/resources/Redacted.java
@@ -1,0 +1,107 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+import static com.spotify.dataenum.DataenumUtils.checkNotNull;
+
+import com.spotify.dataenum.function.Consumer;
+import com.spotify.dataenum.function.Function;
+import java.lang.Boolean;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.Arrays;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.spotify.dataenum.processor.DataEnumProcessor")
+public abstract class Redacted {
+  Redacted() {
+  }
+
+  public static Redacted value(@Nonnull int[] param1, boolean param2) {
+    return new Value(param1, param2);
+  }
+
+  public final boolean isValue() {
+    return (this instanceof Value);
+  }
+
+  public final Value asValue() {
+    return (Value) this;
+  }
+
+  public abstract void match(@Nonnull Consumer<Value> value);
+
+  public abstract <R_> R_ map(@Nonnull Function<Value, R_> value);
+
+  public static final class Value extends Redacted {
+    private final int[] param1;
+
+    private final boolean param2;
+
+    Value(int[] param1, boolean param2) {
+      this.param1 = checkNotNull(param1);
+      this.param2 = param2;
+    }
+
+    @Nonnull
+    public final int[] param1() {
+      return param1;
+    }
+
+    public final boolean param2() {
+      return param2;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) return true;
+      if (!(other instanceof Value)) return false;
+      Value o = (Value) other;
+      return o.param2 == param2
+          && Arrays.equals(o.param1, param1);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 0;
+      result = result * 31 + Arrays.hashCode(this.param1);
+      return result * 31 + Boolean.valueOf(this.param2).hashCode();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Value{param1=").append("***");
+      builder.append(", param2=").append("***");
+      return builder.append('}').toString();
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<Value> value) {
+      value.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<Value, R_> value) {
+      return value.apply(this);
+    }
+  }
+}

--- a/dataenum-processor/src/test/resources/Redacted_dataenum.java
+++ b/dataenum-processor/src/test/resources/Redacted_dataenum.java
@@ -1,0 +1,27 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.Redacted;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+interface Redacted_dataenum {
+  dataenum_case Value(@Redacted int[] param1, @Redacted boolean param2);
+}


### PR DESCRIPTION
Fixes #28.

Array fields aren't really ideal to use in Dataenum, because of mutability, but if you do,
I guess the generated code should be better.