### PR TITLE
Improve Javadoc in generated classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk9
-
-before_install:
-  - echo "MAVEN_OPTS='--add-modules java.xml.bind'" > ~/.mavenrc
+  - oraclejdk11
 
 script:
   - mvn -Pcoverage clean verify

--- a/dataenum-processor/pom.xml
+++ b/dataenum-processor/pom.xml
@@ -71,7 +71,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.9</version>
+                        <version>0.8.4</version>
                         <configuration>
                             <excludes>
                                 <exclude>**/AutoValue_*</exclude>

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/OutputValue.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/OutputValue.java
@@ -24,21 +24,25 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
+import javax.annotation.Nullable;
 
 /** Output-version of value. Contains derived information that wasn't available during parsing. */
 public class OutputValue {
   private final ClassName outputClass;
   private final Iterable<TypeVariableName> typeVariables;
   private final String name;
+  @Nullable private final String javadoc;
   private final Iterable<Parameter> parameters;
 
   public OutputValue(
       ClassName outputClass,
       String name,
+      String javadoc,
       Iterable<Parameter> parameters,
       Iterable<TypeVariableName> typeVariables) {
     this.outputClass = outputClass;
     this.name = name;
+    this.javadoc = javadoc;
     this.parameters = parameters;
     this.typeVariables = typeVariables;
   }
@@ -66,6 +70,11 @@ public class OutputValue {
 
   public String name() {
     return name;
+  }
+
+  @Nullable
+  public String javadoc() {
+    return javadoc;
   }
 
   public Iterable<Parameter> parameters() {

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/Value.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/Value.java
@@ -20,19 +20,27 @@
 package com.spotify.dataenum.processor.data;
 
 import com.spotify.dataenum.processor.util.Iterables;
+import javax.annotation.Nullable;
 
 /** Represents one of the possible values of a dataenum spec. */
 public class Value {
   private final String simpleName;
+  @Nullable private final String javadoc;
   private final Iterable<Parameter> parameters;
 
-  public Value(String simpleName, Iterable<Parameter> parameters) {
+  public Value(String simpleName, String javadoc, Iterable<Parameter> parameters) {
     this.simpleName = simpleName;
+    this.javadoc = javadoc;
     this.parameters = parameters;
   }
 
   public String name() {
     return simpleName;
+  }
+
+  @Nullable
+  public String javadoc() {
+    return javadoc;
   }
 
   public Iterable<Parameter> parameters() {

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
@@ -51,7 +51,7 @@ final class OutputValueFactory {
       parameters.add(parameterWithoutDataEnumSuffix(parameter));
     }
 
-    return new OutputValue(outputClass, value.name(), parameters, typeVariables);
+    return new OutputValue(outputClass, value.name(), value.javadoc(), parameters, typeVariables);
   }
 
   private static Parameter parameterWithoutDataEnumSuffix(Parameter parameter)

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
@@ -70,7 +70,7 @@ public final class SpecTypeFactory {
     TypeSpec.Builder enumBuilder =
         TypeSpec.classBuilder(spec.outputClass())
             .addOriginatingElement(element)
-            .addJavadoc("Generated from {@link $T}", spec.specClass())
+            .addJavadoc("Generated from {@link $T}\n", spec.specClass())
             .addAnnotation(
                 AnnotationSpec.builder(Generated.class)
                     .addMember(

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/spec/SpecTypeFactory.java
@@ -70,6 +70,7 @@ public final class SpecTypeFactory {
     TypeSpec.Builder enumBuilder =
         TypeSpec.classBuilder(spec.outputClass())
             .addOriginatingElement(element)
+            .addJavadoc("Generated from {@link $T}", spec.specClass())
             .addAnnotation(
                 AnnotationSpec.builder(Generated.class)
                     .addMember(

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueMethods.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueMethods.java
@@ -46,6 +46,16 @@ public class ValueMethods {
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .returns(spec.parameterizedOutputClass());
 
+    if (value.javadoc() != null) {
+      factory.addJavadoc(value.javadoc() + "\n\n");
+    }
+
+    factory.addJavadoc(
+        "@return a {@link $T} (see {@link $T#$L} for source)\n",
+        value.outputClass(),
+        spec.specClass(),
+        value.name());
+
     StringBuilder newString = new StringBuilder();
     List<Object> newArgs = new ArrayList<>();
 

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/parser/ValueParser.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/parser/ValueParser.java
@@ -98,8 +98,14 @@ final class ValueParser {
       parameters.add(new Parameter(parameterName, parameterType, nullable, redacted, isEnum));
     }
 
+    String javadoc = processingEnv.getElementUtils().getDocComment(element);
+
+    if (javadoc != null) {
+      javadoc = javadoc.trim();
+    }
+
     String valueSimpleName = methodElement.getSimpleName().toString();
-    return new Value(valueSimpleName, parameters);
+    return new Value(valueSimpleName, javadoc, parameters);
   }
 
   private static boolean isAnnotationPresent(

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -231,12 +231,47 @@ public class IntegrationTest {
         javac()
             .withOptions("-implicit:class")
             .withProcessors(new DataEnumProcessor())
-            .compile(JavaFileObjects.forResource("ArrayFields_dataenum.java"));
+            .compile(JavaFileObjects.forResource("javadoc/Javadoc_dataenum.java"));
 
     assertThat(compilation).succeededWithoutWarnings();
     assertThat(compilation)
-        .generatedSourceFile("ArrayFields")
+        .generatedSourceFile("javadoc.Javadoc")
         .contentsAsUtf8String()
-        .contains(" * Generated from {@link ArrayFields_dataenum}");
+        .contains(" * Generated from {@link Javadoc_dataenum}");
+  }
+
+  @Test
+  public void shouldGenerateLinkToCaseSourceAsJavadocCommentOnFactoryMethod() {
+    Compilation compilation =
+        javac()
+            .withOptions("-implicit:class")
+            .withProcessors(new DataEnumProcessor())
+            .compile(JavaFileObjects.forResource("javadoc/Javadoc_dataenum.java"));
+
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("javadoc.Javadoc")
+        .contentsAsUtf8String()
+        .contains("   * @return a {@link Value} (see {@link Javadoc_dataenum#Value} for source)");
+  }
+
+  @Test
+  public void shouldCopyDocFromCaseSourceToJavadocCommentOnFactoryMethod() {
+    Compilation compilation =
+        javac()
+            .withOptions("-implicit:class")
+            .withProcessors(new DataEnumProcessor())
+            .compile(JavaFileObjects.forResource("javadoc/Javadoc_dataenum.java"));
+
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("javadoc.Javadoc")
+        .contentsAsUtf8String()
+        .contains(
+            "/**\n"
+                + "   * Some documentation about this case.\n"
+                + "   *\n"
+                + "   * @return a {@link Documented} (see {@link Javadoc_dataenum#Documented} for source)\n"
+                + "   */\n");
   }
 }

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -224,4 +224,19 @@ public class IntegrationTest {
     assertThat(compilation).hadErrorContaining("Duplicate case name 'value'");
     assertThat(compilation).hadErrorContaining("Duplicate case name 'caseisimportant'");
   }
+
+  @Test
+  public void shouldGenerateLinkToSourceAsJavadocComment() {
+    Compilation compilation =
+        javac()
+            .withOptions("-implicit:class")
+            .withProcessors(new DataEnumProcessor())
+            .compile(JavaFileObjects.forResource("ArrayFields_dataenum.java"));
+
+    assertThat(compilation).succeededWithoutWarnings();
+    assertThat(compilation)
+        .generatedSourceFile("ArrayFields")
+        .contentsAsUtf8String()
+        .contains(" * Generated from {@link ArrayFields_dataenum}");
+  }
 }

--- a/dataenum-processor/src/test/resources/javadoc/Javadoc_dataenum.java
+++ b/dataenum-processor/src/test/resources/javadoc/Javadoc_dataenum.java
@@ -1,0 +1,34 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package javadoc;
+
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+interface Javadoc_dataenum {
+
+  /**
+   * Some documentation about this case.
+   */
+  dataenum_case Documented();
+
+  dataenum_case Value();
+}

--- a/dataenum/pom.xml
+++ b/dataenum/pom.xml
@@ -61,7 +61,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.9</version>
+                        <version>0.8.4</version>
                         <configuration>
                             <excludes>
                                 <exclude>**/AutoValue_*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.11.0</version>
+                    <version>0.14.1</version>
                     <configuration>
                         <oldVersion>
                             <dependency>
@@ -159,14 +159,14 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.3.1</version>
+                    <version>3.1.12</version>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
@@ -202,7 +202,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.9</version>
+                        <version>0.8.4</version>
                         <configuration>
                             <excludes>
                                 <exclude>**/AutoValue_*</exclude>


### PR DESCRIPTION
This PR does the following:

1. Adds a link to the original `_dataenum` definition as a top-level comment in the generated source.
1. Adds a link from each case factory method to the case definition in the source `_dataenum`.
1. If a case definition has javadoc comments, it copies these comments to the case factory method.

It also makes some changes to dependencies and Travis config in order to keep up with developments in JDKs.