### PR TITLE
add support for copying annotations from spec to generated source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk11
+  - openjdk11
 
 script:
   - mvn -Pcoverage clean verify

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/OutputValue.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/OutputValue.java
@@ -20,6 +20,7 @@
 package com.spotify.dataenum.processor.data;
 
 import com.spotify.dataenum.processor.util.Iterables;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
@@ -33,18 +34,21 @@ public class OutputValue {
   private final String name;
   @Nullable private final String javadoc;
   private final Iterable<Parameter> parameters;
+  private final Iterable<AnnotationSpec> annotations;
 
   public OutputValue(
       ClassName outputClass,
       String name,
       String javadoc,
       Iterable<Parameter> parameters,
-      Iterable<TypeVariableName> typeVariables) {
+      Iterable<TypeVariableName> typeVariables,
+      Iterable<AnnotationSpec> annotations) {
     this.outputClass = outputClass;
     this.name = name;
     this.javadoc = javadoc;
     this.parameters = parameters;
     this.typeVariables = typeVariables;
+    this.annotations = annotations;
   }
 
   public ClassName outputClass() {
@@ -83,5 +87,9 @@ public class OutputValue {
 
   public boolean hasParameters() {
     return !Iterables.isEmpty(parameters());
+  }
+
+  public Iterable<AnnotationSpec> annotations() {
+    return annotations;
   }
 }

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/Value.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/data/Value.java
@@ -20,6 +20,7 @@
 package com.spotify.dataenum.processor.data;
 
 import com.spotify.dataenum.processor.util.Iterables;
+import com.squareup.javapoet.AnnotationSpec;
 import javax.annotation.Nullable;
 
 /** Represents one of the possible values of a dataenum spec. */
@@ -27,11 +28,17 @@ public class Value {
   private final String simpleName;
   @Nullable private final String javadoc;
   private final Iterable<Parameter> parameters;
+  private final Iterable<AnnotationSpec> annotations;
 
-  public Value(String simpleName, String javadoc, Iterable<Parameter> parameters) {
+  public Value(
+      String simpleName,
+      String javadoc,
+      Iterable<Parameter> parameters,
+      Iterable<AnnotationSpec> annotations) {
     this.simpleName = simpleName;
     this.javadoc = javadoc;
     this.parameters = parameters;
+    this.annotations = annotations;
   }
 
   public String name() {
@@ -49,5 +56,9 @@ public class Value {
 
   public boolean hasParameters() {
     return !Iterables.isEmpty(parameters());
+  }
+
+  public Iterable<AnnotationSpec> annotations() {
+    return annotations;
   }
 }

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/data/OutputValueFactory.java
@@ -51,7 +51,8 @@ final class OutputValueFactory {
       parameters.add(parameterWithoutDataEnumSuffix(parameter));
     }
 
-    return new OutputValue(outputClass, value.name(), value.javadoc(), parameters, typeVariables);
+    return new OutputValue(
+        outputClass, value.name(), value.javadoc(), parameters, typeVariables, value.annotations());
   }
 
   private static Parameter parameterWithoutDataEnumSuffix(Parameter parameter)

--- a/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueMethods.java
+++ b/dataenum-processor/src/main/java/com/spotify/dataenum/processor/generator/value/ValueMethods.java
@@ -22,6 +22,7 @@ package com.spotify.dataenum.processor.generator.value;
 import com.spotify.dataenum.processor.data.OutputSpec;
 import com.spotify.dataenum.processor.data.OutputValue;
 import com.spotify.dataenum.processor.data.Parameter;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.ParameterSpec;
@@ -55,6 +56,10 @@ public class ValueMethods {
         value.outputClass(),
         spec.specClass(),
         value.name());
+
+    for (AnnotationSpec annotationSpec : value.annotations()) {
+      factory.addAnnotation(annotationSpec);
+    }
 
     StringBuilder newString = new StringBuilder();
     List<Object> newArgs = new ArrayList<>();

--- a/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
+++ b/dataenum-processor/src/test/java/com/spotify/dataenum/processor/IntegrationTest.java
@@ -274,4 +274,9 @@ public class IntegrationTest {
                 + "   * @return a {@link Documented} (see {@link Javadoc_dataenum#Documented} for source)\n"
                 + "   */\n");
   }
+
+  @Test
+  public void shouldCopyAnnotationsFromCaseSourceToFactoryMethod() {
+    assertThatEnumGeneratedMatchingFile("annotation/Annotation", "annotation/MyAnnotation.java");
+  }
 }

--- a/dataenum-processor/src/test/resources/annotation/Annotation.java
+++ b/dataenum-processor/src/test/resources/annotation/Annotation.java
@@ -41,17 +41,32 @@ public abstract class Annotation {
     return new AnnotatedWithParams();
   }
 
+  @MyAnnotation(foo = "hi")
+  public static Annotation annotatedWithDefault() {
+    return new AnnotatedWithDefault();
+  }
+
   public final boolean isAnnotatedWithParams() {
     return (this instanceof AnnotatedWithParams);
+  }
+
+  public final boolean isAnnotatedWithDefault() {
+    return (this instanceof AnnotatedWithDefault);
   }
 
   public final AnnotatedWithParams asAnnotatedWithParams() {
     return (AnnotatedWithParams) this;
   }
 
-  public abstract void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams);
+  public final AnnotatedWithDefault asAnnotatedWithDefault() {
+    return (AnnotatedWithDefault) this;
+  }
 
-  public abstract <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams);
+  public abstract void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams,
+      @Nonnull Consumer<AnnotatedWithDefault> annotatedWithDefault);
+
+  public abstract <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams,
+      @Nonnull Function<AnnotatedWithDefault, R_> annotatedWithDefault);
 
   public static final class AnnotatedWithParams extends Annotation {
     AnnotatedWithParams() {
@@ -73,13 +88,47 @@ public abstract class Annotation {
     }
 
     @Override
-    public final void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams) {
+    public final void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams,
+        @Nonnull Consumer<AnnotatedWithDefault> annotatedWithDefault) {
       annotatedWithParams.accept(this);
     }
 
     @Override
-    public final <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams) {
+    public final <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams,
+        @Nonnull Function<AnnotatedWithDefault, R_> annotatedWithDefault) {
       return annotatedWithParams.apply(this);
+    }
+  }
+
+  public static final class AnnotatedWithDefault extends Annotation {
+    AnnotatedWithDefault() {
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof AnnotatedWithDefault;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return "AnnotatedWithDefault{}";
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams,
+        @Nonnull Consumer<AnnotatedWithDefault> annotatedWithDefault) {
+      annotatedWithDefault.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams,
+        @Nonnull Function<AnnotatedWithDefault, R_> annotatedWithDefault) {
+      return annotatedWithDefault.apply(this);
     }
   }
 }

--- a/dataenum-processor/src/test/resources/annotation/Annotation.java
+++ b/dataenum-processor/src/test/resources/annotation/Annotation.java
@@ -1,0 +1,85 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package annotation;
+
+import com.spotify.dataenum.function.Consumer;
+import com.spotify.dataenum.function.Function;
+import java.lang.Deprecated;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+
+@Generated("com.spotify.dataenum.processor.DataEnumProcessor")
+public abstract class Annotation {
+  Annotation() {
+  }
+
+  @SuppressWarnings({"floopity", "floop"})
+  @Deprecated
+  @MyAnnotation(foo = "hi", fie = 15)
+  public static Annotation annotatedWithParams() {
+    return new AnnotatedWithParams();
+  }
+
+  public final boolean isAnnotatedWithParams() {
+    return (this instanceof AnnotatedWithParams);
+  }
+
+  public final AnnotatedWithParams asAnnotatedWithParams() {
+    return (AnnotatedWithParams) this;
+  }
+
+  public abstract void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams);
+
+  public abstract <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams);
+
+  public static final class AnnotatedWithParams extends Annotation {
+    AnnotatedWithParams() {
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof AnnotatedWithParams;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return "AnnotatedWithParams{}";
+    }
+
+    @Override
+    public final void match(@Nonnull Consumer<AnnotatedWithParams> annotatedWithParams) {
+      annotatedWithParams.accept(this);
+    }
+
+    @Override
+    public final <R_> R_ map(@Nonnull Function<AnnotatedWithParams, R_> annotatedWithParams) {
+      return annotatedWithParams.apply(this);
+    }
+  }
+}

--- a/dataenum-processor/src/test/resources/annotation/Annotation_dataenum.java
+++ b/dataenum-processor/src/test/resources/annotation/Annotation_dataenum.java
@@ -28,4 +28,7 @@ interface Annotation_dataenum {
   @Deprecated
   @MyAnnotation(foo = "hi", fie = 15)
   dataenum_case AnnotatedWithParams();
+
+  @MyAnnotation(foo = "hi")
+  dataenum_case AnnotatedWithDefault();
 }

--- a/dataenum-processor/src/test/resources/annotation/Annotation_dataenum.java
+++ b/dataenum-processor/src/test/resources/annotation/Annotation_dataenum.java
@@ -1,0 +1,31 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package annotation;
+
+import com.spotify.dataenum.DataEnum;
+import com.spotify.dataenum.dataenum_case;
+
+@DataEnum
+interface Annotation_dataenum {
+  @SuppressWarnings({"floopity", "floop"})
+  @Deprecated
+  @MyAnnotation(foo = "hi", fie = 15)
+  dataenum_case AnnotatedWithParams();
+}

--- a/dataenum-processor/src/test/resources/annotation/MyAnnotation.java
+++ b/dataenum-processor/src/test/resources/annotation/MyAnnotation.java
@@ -29,5 +29,5 @@ import java.lang.annotation.Target;
 @Target(METHOD)
 public @interface MyAnnotation {
   String foo();
-  int fie();
+  int fie() default 99;
 }

--- a/dataenum-processor/src/test/resources/annotation/MyAnnotation.java
+++ b/dataenum-processor/src/test/resources/annotation/MyAnnotation.java
@@ -1,0 +1,33 @@
+/*
+ * -\-\-
+ * DataEnum
+ * --
+ * Copyright (c) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package annotation;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface MyAnnotation {
+  String foo();
+  int fie();
+}


### PR DESCRIPTION
This is needed in order to support lint checks that methods documented as deprecated
are also annotated as deprecated.