### PR TITLE
Replace jsr250 with lib integrated in java

### DIFF
--- a/dataenum-processor/pom.xml
+++ b/dataenum-processor/pom.xml
@@ -22,8 +22,8 @@
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-            <version>1.0</version>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Goal
Replace JSR 250 with [Java SE library since Java6](https://en.wikipedia.org/wiki/JSR_250)

## Why
jsr250 and javax.annotation-api cover the same classes. Having both dependency create duplicated class for static analyzis of the dependencies. Using the Java SE library would make more sense to avoid this kind of issue.